### PR TITLE
Expose binary.

### DIFF
--- a/bin/getdocs.js
+++ b/bin/getdocs.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var fs = require("fs")
 var glob = require("glob")
 var getdocs = require("../src")

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.5.0",
   "description": "An extractor for succinct documentation comments in JavaScript code",
   "main": "src/index.js",
+  "bin": {
+    "getdocs": "bin/getdocs.js"
+  },
   "scripts": {
     "test": "node test/run.js"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ exports.stripComment = docComments.stripComment
 var parseType = exports.parseType = require("./parsetype")
 
 exports.gather = function(text, options) {
-  let items = options.items || Object.create(null)
+  var items = options.items || Object.create(null)
   var top = {properties: items}
 
   var found = docComments.parse(text, options)


### PR DESCRIPTION
This exposes the binary so you can just run `getdocs` on a global install.  I originally expected this when going through the readme but realized it wasn't there.  Also, I had to switch one "let" to "var" to get around a strict mode error in Node 4.
